### PR TITLE
Fixed typographical error, changed abudance to abundance in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ http://www.pnas.org/content/111/28/E2875
 
 This repository contains two R scripts and some data files we used to generate results in the paper:
 
-- [analysis-of-differential-abudance.R](https://github.com/meren/hmp-oral-microbiota/blob/master/analysis-of-differential-abudance.R): This script identifies the site preference of an oligotype in the human oral cavity and reports its significance. Please read the __Calculation of Site Preferences__ section under [Material and Methods](http://www.pnas.org/content/111/28/E2875.full#sec-18) in our manuscript.
+- [analysis-of-differential-abundance.R](https://github.com/meren/hmp-oral-microbiota/blob/master/analysis-of-differential-abundance.R): This script identifies the site preference of an oligotype in the human oral cavity and reports its significance. Please read the __Calculation of Site Preferences__ section under [Material and Methods](http://www.pnas.org/content/111/28/E2875.full#sec-18) in our manuscript.
 - [generate-figures.R](https://github.com/meren/hmp-oral-microbiota/blob/master/generate-figures.R): We used these functions to generate Figures 2, 3, 4 and 5 in the manuscript. If you simply run it, the script will generate three example figures.
 - v1v3 and v3v5 directories contain data files that are used either of these scripts.
 


### PR DESCRIPTION
meren, I've corrected a typographical error in the documentation of the [hmp-oral-microbiota](https://github.com/meren/hmp-oral-microbiota) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
